### PR TITLE
Fix: Require Terraform version 1.10

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9.0"
+  required_version = ">= 1.10.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Require Terraform version 1.10 to support negative indexes in element function